### PR TITLE
Fixing an issue with the hookData referencing an undefined page

### DIFF
--- a/mocha-phantomjs-core.js
+++ b/mocha-phantomjs-core.js
@@ -18,6 +18,22 @@ if (phantom.version.major < 1 || (phantom.version.major === 1 && phantom.version
   phantom.exit(-2)
 }
 
+// Create and configure the client page
+var
+  output = config.file ? fs.open(config.file, 'w') : system.stdout,
+  page = webpage.create({
+    settings: config.settings
+  }),
+  fail = function(msg, errno) {
+    if (output && config.file) {
+      output.close()
+    }
+    if (msg) {
+      system.stderr.writeLine(msg)
+    }
+    return phantom.exit(errno || 1)
+  }
+
 if (config.hooks) {
   hookData = {
     page: page,
@@ -34,22 +50,6 @@ if (config.hooks) {
 } else {
   config.hooks = {}
 }
-
-// Create and configure the client page
-var
-  output = config.file ? fs.open(config.file, 'w') : system.stdout,
-  page = webpage.create({
-    settings: config.settings
-  }),
-  fail = function(msg, errno) {
-    if (output && config.file) {
-      output.close()
-    }
-    if (msg) {
-      system.stderr.writeLine(msg)
-    }
-    return phantom.exit(errno || 1)
-  }
 
 if (config.headers) {
   page.customHeaders = config.headers


### PR DESCRIPTION
I'm using gulp-mocha-phantomjs in combination with the mocha-phantomjs-istanbul plugin to be able to report code coverage. The problem is the plugin reporting the code coverage is relying on the page property of the hookData to be set. The current code creates the hookData before the page variable has been set. I'm just reversing these two blocks of code so that the page variable can be set before the hookData is created.
