### PR TITLE
Handle failed iframe load

### DIFF
--- a/mocha-phantomjs-core.js
+++ b/mocha-phantomjs-core.js
@@ -113,6 +113,7 @@ page.onCallback = function(data) {
   return true
 }
 page.onLoadFinished = function(status) {
+  page.onLoadFinished = null
   if (status !== 'success') {
     fail('Failed to load the page. Check the url: ' + url)
   } else if (!configured) {


### PR DESCRIPTION
This PR fix the problem where an aborted iframe load could cause mocha-phantomjs to fail.

PhantomJS intentionally calls `page.onLoadFinished` on iframe load and returns fail when iframe load is failed or aborted:

``` coffeescript
var iframe = document.createElement("iframe");
document.body.appendChild(iframe);
iframe.src = "http://fail/";
```

```
Error loading resource http://fail/ (3). Details: Host fail not found
Failed to load the page. Check the url: test.html
```

This is just an extreme case that can be reproduce easily. In the real world, removing an iframe in loading from DOM (to speed up tests) could also trigger this problem.

`mocha-phantomjs` should keep running when iframe fails because test cases would fail as intended.

In short, `page.onLoadFinished` should be called only once on the test page itself.
