### PR TITLE
Configurable root suite timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Boolean. Suppress the resource failure output that `mocha-phantomjs-core` will o
 
 #### `timeout`
 
-Time in milliseconds after the page loads that `mocha.run` needs to be called. Defaults to 10 seconds.
+Time in milliseconds after the page loads that `mocha.run` needs to be called. Also sets mocha's root suite timeout. Defaults to 10 seconds.
 
 #### `viewportSize`
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ Boolean. Stop the test run at the first failure if true. Defaults to false.
 
 Boolean. Suppress the resource failure output that `mocha-phantomjs-core` will output by default.
 
+#### `loadTimeout`
+
+Time in milliseconds after the page loads that `mocha.run` needs to be called. Defaults to 10 seconds. 
+
 #### `timeout`
 
-Time in milliseconds after the page loads that `mocha.run` needs to be called. Also sets mocha's root suite timeout. Defaults to 10 seconds.
+Sets mocha's root suite timeout. Defers to mocha's default if omitted. 
 
 #### `viewportSize`
 

--- a/mocha-phantomjs-core.js
+++ b/mocha-phantomjs-core.js
@@ -124,20 +124,20 @@ page.onLoadFinished = function(status) {
     return
   }
 
-  var timeout = config.timeout || 10000
+  var loadTimeout = config.loadTimeout || 10000
   setTimeout(function() {
     if (!configured) {
       if (page.evaluate(function() { return !window.mocha })) {
-        fail('mocha was not found in the page within ' + timeout + 'ms of the page loading.')
+        fail('mocha was not found in the page within ' + loadTimeout + 'ms of the page loading.')
       } else if (page.evaluate(function() { return window.initMochaPhantomJS })) {
         fail('Likely due to external resource loading and timing, your tests require calling `window.initMochaPhantomJS()` before calling any mocha setup functions. See https://github.com/nathanboktae/mocha-phantomjs-core/issues/12')
       } else {
-        fail('mocha was not initialized within ' + timeout + 'ms of the page loading. Make sure to call `mocha.ui` or `mocha.setup`.')
+        fail('mocha was not initialized within ' + loadTimeout + 'ms of the page loading. Make sure to call `mocha.ui` or `mocha.setup`.')
       }
     } else if (!runStarted) {
-      fail('mocha.run() was not called within ' + timeout + 'ms of the page loading.')
+      fail('mocha.run() was not called within ' + loadTimeout + 'ms of the page loading.')
     }
-  }, timeout)
+  }, loadTimeout)
 }
 
 function configureMocha() {

--- a/mocha-phantomjs-core.js
+++ b/mocha-phantomjs-core.js
@@ -147,6 +147,9 @@ function configureMocha() {
 
     mocha.useColors(config.useColors)
     mocha.bail(config.bail)
+    if (config.timeout) {
+      mocha.timeout(config.timeout)
+    }
     if (config.grep) {
       mocha.grep(config.grep)
     }

--- a/test/core.tests.coffee
+++ b/test/core.tests.coffee
@@ -296,6 +296,14 @@ describe 'mocha-phantomjs-core', ->
 
         stdout.should.contain '1 failing'
 
+    describe 'timeout', ->
+      it 'should set the root suite timeout', ->
+        { stdout } = yield run
+          test: 'slow'
+          timeout: 300
+
+        stdout.should.contain '3 failing'
+
     describe 'file', ->
       it 'pipes reporter output to a file', ->
         { stdout } = yield run

--- a/test/core.tests.coffee
+++ b/test/core.tests.coffee
@@ -59,17 +59,17 @@ describe 'mocha-phantomjs-core', ->
     code.should.equal 0
 
   it 'returns a failure code when mocha can not be found on the page', ->
-    { code, stderr } = yield run { test: 'blank', timeout: 300 }
+    { code, stderr } = yield run { test: 'blank', loadTimeout: 300 }
     code.should.equal 1
     stderr.should.contain 'mocha was not found in the page within 300ms of the page loading'
 
   it 'returns a failure code when mocha fails to start for any reason', ->
-    { code, stderr } = yield run { test: 'bad', timeout: 300 }
+    { code, stderr } = yield run { test: 'bad', loadTimeout: 300 }
     code.should.equal 1
     stderr.should.contain 'mocha was not initialized within 300ms of the page loading'
 
-  it 'returns a failure code when mocha is not started within the timeout after the page loads', ->
-    { code, stderr } = yield run { test: 'no-mocha-run', timeout: 500 }
+  it 'returns a failure code when mocha is not started within the loadTimeout after the page loads', ->
+    { code, stderr } = yield run { test: 'no-mocha-run', loadTimeout: 500 }
     code.should.not.equal 0
     stderr.should.match /mocha.run\(\) was not called within 500ms of the page loading/
 
@@ -156,7 +156,7 @@ describe 'mocha-phantomjs-core', ->
       code.should.equal 0
 
     it 'should give an informative message when initMochaPhantomJS is required', ->
-      { code, stderr } = yield run { test: 'external-sources', query: { skipinit: true }, timeout: 300 }
+      { code, stderr } = yield run { test: 'external-sources', query: { skipinit: true }, loadTimeout: 300 }
       stderr.should.contain 'your tests require calling `window.initMochaPhantomJS()` before calling any mocha setup functions'
       code.should.equal 1
 


### PR DESCRIPTION
This changes the behavior of the timeout configuration parameter to set the root suite timeout for mocha in addition to imposing a timeout on mocha launching. 

In a way this constitutes a breaking change, however I think this is what most people would have expected.

My use case for this change is wanting to set a higher timeout when running tests in phantomjs compared to chrome, as I found that some tests that ran quickly in chrome ran significantly slower in phantomjs and were exceeding the default timeout of 2000 ms - without maintaining separate html files for this purpose.
