### PR TITLE
getColWith -> configureColWidth

### DIFF
--- a/browser-shim.js
+++ b/browser-shim.js
@@ -28,7 +28,7 @@
     M.process = M.process || {}
     M.process.stdout = M.process.stdout || process.stdout
     M.process.stdout.write = function(s) { window.callPhantom({ stdout: s }) }
-    window.callPhantom({ getColWith: true })
+    window.callPhantom({ configureColWidth: true })
   }
 
   function shimMochaInstance(m) {


### PR DESCRIPTION
As it is named that way in `mocha-phantomjs-core.js`
This bug caused the reporters to not have the right column width of the screen.

This was introduced by https://github.com/nathanboktae/mocha-phantomjs-core/commit/99886e5ce56d2276a0c36679c5b82f1afe52dee6, where both `getColWidth` and `configureColWidth` were are inserted in these two files.